### PR TITLE
use twitter api v2 to get user details as 1.1 api support is removed

### DIFF
--- a/src/Server/Twitter.php
+++ b/src/Server/Twitter.php
@@ -81,7 +81,7 @@ class Twitter extends Server
      */
     public function urlUserDetails()
     {
-        return 'https://api.twitter.com/1.1/account/verify_credentials.json?include_email=true';
+        return 'https://api.twitter.com/2/account/verify_credentials?include_email=true';
     }
 
     /**


### PR DESCRIPTION
old api endpoint no longer return user details:
https://api.twitter.com/1.1/account/verify_credentials.json?include_email=true

new endpoint is:
https://api.twitter.com/2/account/verify_credentials?include_email=true